### PR TITLE
CORE-3115-Prefix space in column type causing the Unknown LiquibaseDa…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -134,7 +134,7 @@ public class DataTypeFactory {
             // not going to do anything. Special case for postgres in our tests,
             // need to better support handling these types of differences
         } else {
-            String[] splitTypeName = dataTypeName.split("\\s+", 2);
+            String[] splitTypeName = dataTypeName.trim().split("\\s+", 2);
             dataTypeName = splitTypeName[0];
             if (splitTypeName.length > 1) {
                 additionalInfo = splitTypeName[1];


### PR DESCRIPTION
…taType with the latest release

Prefix space in column type causing Unknown LiquibaseDataType with the Latest Liquibase release 3.5.3.
We have recently upgraded from liquibase 2.0.5 to 3.5.3 and the existing scripts are failing with the latest version. We are not able to change it as it was already executed on the database which will fail if we change any.
Ex: <column name="REASON" type=" VARCHAR2(50)"/>
When you have space as a prefix to the attribute type value, The Liquibase splitting it with '/s ' and taking first parameter as dataTypeName which is causing Unknown LiquibaseDataType.
It is better to trim the dataTypeName before splitting in DataTypeFactory.java.
Fix:
DataTypeFactory.java
 String[] splitTypeName = dataTypeName.trim().split("\\s+", 2);
            dataTypeName = splitTypeName[0];
            if (splitTypeName.length > 1) {
                additionalInfo = splitTypeName[1];
            }